### PR TITLE
fix: Refactor for proper unit testing

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -1,0 +1,5 @@
+function bestify(name) {
+    return name + " is the best"
+}
+
+module.exports = bestify;

--- a/index.js
+++ b/index.js
@@ -1,15 +1,13 @@
 const express = require('express')
+const bestify = require('./functions')
 const app = express()
 const port = 3000
 
 app.get('/', (req, res) => res.send("Hello world"))
 
-function bestify(name) {
-    return name + " is the best"
-}
+
 
 app.get('/antoine', (req,res) => res.send(bestify('Antoine')))
 
 app.listen(port, () => console.log("Example app listening on port %s!",port))
 
-module.exports = bestify;

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -1,4 +1,4 @@
-const bestify = require('../index.js');
+const bestify = require('../functions');
 
 test('Bestify should return name is the best', () => {
     expect(bestify('Antoine')).toBe('Antoine is the best');


### PR DESCRIPTION
Move bestify into its own file, leaving web traffic handling the main index.js.
Allows unit tests to load only the function we want to test, without running express. Express behavior will be tested in a different set of tests.